### PR TITLE
master

### DIFF
--- a/include/main.h
+++ b/include/main.h
@@ -42,7 +42,8 @@ void step_until_sufficient_decorrelation(
  */
 void sample(const std::string hypersurface_input_file,
             HyperSurfacePatch::InputFormat hypersurface_file_format,
-            const std::string output_file, size_t N_warmup,
+            const std::string output_file,
+            const std::string patches_output_filename, size_t N_warmup,
             size_t N_decorrelate, size_t N_printout,
             double max_mass, double Epatch);
 

--- a/include/microcanonical_sampler.h
+++ b/include/microcanonical_sampler.h
@@ -50,6 +50,8 @@ public:
                   SamplerParticleList &particles);
   void one_markov_chain_step(const HyperSurfacePatch &hypersurface,
                              SamplerParticleList &particles);
+  void random_two_to_two(const HyperSurfacePatch &hypersurface,
+                           SamplerParticleList &particles);
 
   /// Set the level of debug printout
   void set_debug_printout(int a) { debug_printout_ = a; }
@@ -85,8 +87,6 @@ private:
   void random_two_to_three(const HyperSurfacePatch &hypersurface,
                            SamplerParticleList &particles);
   void random_three_to_two(const HyperSurfacePatch &hypersurface,
-                           SamplerParticleList &particles);
-  void random_two_to_two(const HyperSurfacePatch &hypersurface,
                            SamplerParticleList &particles);
   void renormalize_momenta(const smash::FourVector &required_4mom,
                            SamplerParticleList &particles);

--- a/include/microcanonical_sampler.h
+++ b/include/microcanonical_sampler.h
@@ -86,6 +86,8 @@ private:
                            SamplerParticleList &particles);
   void random_three_to_two(const HyperSurfacePatch &hypersurface,
                            SamplerParticleList &particles);
+  void random_two_to_two(const HyperSurfacePatch &hypersurface,
+                           SamplerParticleList &particles);
   void renormalize_momenta(const smash::FourVector &required_4mom,
                            SamplerParticleList &particles);
 

--- a/microcanonical_sampler.cc
+++ b/microcanonical_sampler.cc
@@ -666,8 +666,8 @@ void MicrocanonicalSampler::random_two_to_two(
   phitheta.distribute_isotropically();
   const smash::ThreeVector mom = p_cm * phitheta.threevec();
   const double mom2 = p_cm * p_cm;
-  smash::FourVector p1(std::sqrt(mom2 + m1 * m1), mom),
-      p2(std::sqrt(mom2 + m2 * m2), -mom);
+  out[0].momentum = smash::FourVector(std::sqrt(mom2 + m1 * m1),  mom);
+  out[1].momentum = smash::FourVector(std::sqrt(mom2 + m2 * m2), -mom);
   for (SamplerParticle &part : out) {
     part.momentum = part.momentum.LorentzBoost(-beta_cm);
   }

--- a/test_sampler.cc
+++ b/test_sampler.cc
@@ -125,6 +125,9 @@ void sample(const std::string hypersurface_input_file,
     for (int i = 0; i < N_warmup; ++i) {
       sampler.one_markov_chain_step(patches[i_patch], particles[i_patch]);
     }
+    for (int i = 0; i < N_warmup; ++i) {
+      sampler.random_two_to_two(patches[i_patch], particles[i_patch]);
+    }
   }
   std::cout << "Finished warming up." << std::endl;
   size_t total_particles = 0;
@@ -145,6 +148,9 @@ void sample(const std::string hypersurface_input_file,
     for (size_t i_patch = 0; i_patch < number_of_patches; i_patch++) {
       for (int i = 0; i < N_decorrelate; ++i) {
         sampler.one_markov_chain_step(patches[i_patch], particles[i_patch]);
+      }
+      for (int i = 0; i < N_decorrelate; ++i) {
+        sampler.random_two_to_two(patches[i_patch], particles[i_patch]);
       }
     }
     // print out


### PR DESCRIPTION
Hi, This has been a very nice progress which have a good way to mimic the local charge conservation effect. My research is very _sensitive to the tiny difference between number of positive versus negative particles created in a single cell/patch_, characterized by the local chemical potential.
I wonder if you could please make the following modifications:
1) Could you please add an extra scheme which rounds the N_PID or N_cc up or down "randomly" according to the **non-integer part of its expectation value**? This could capture the tiny difference in e.g. pi^+ versus pi^- created in a single patch. (N_PID = "number of identified particles", N_cc = "number of conserved charge")
2) It would be very meaningful to test the sensitivity on **different definition of space-time correlation function**. I would really appreciate it if you could add different possible definitions as different modes/schemes of the simulation, as well as add a corresponding switch.